### PR TITLE
chore: add repository, homepage and bugs fields to package.json

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -27,6 +27,15 @@
     "bun": ">=1.1.0"
   },
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/memory-graph/memory-graph.git",
+    "directory": "ts"
+  },
+  "homepage": "https://memory-graph.github.io/memory-graph/",
+  "bugs": {
+    "url": "https://github.com/memory-graph/memory-graph/issues"
+  },
   "keywords": [
     "memory",
     "knowledge-graph",


### PR DESCRIPTION
### Summary

`ts/package.json` has no `repository`, `homepage` or `bugs` fields, so there is no path from an installed copy of the package back to this repository.

### Why it matters

I hit this while debugging a locally installed `memorygraph`. Having traced a bug to a specific line in `ts/src/backends/sqlite.ts`, I went looking for somewhere to report it and found nothing in the manifest — I concluded there was no public repo to file against and stopped. I only found this repo later, from a link someone sent me. Concretely, from an installed copy:

- `npm repo memorygraph` and `npm bugs memorygraph` both fail
- the npm page shows no "Repository" or "Issues" link
- tooling that reads `repository` to build source links has nothing to work with

For a tool whose users are agents and the people debugging them, that dead end costs real time and loses bug reports that would otherwise get filed.

### Changes

Added the three standard metadata fields:

- `repository` — with `directory: "ts"`, since the manifest lives in a subdirectory rather than at the repo root
- `homepage` — the existing GitHub Pages site
- `bugs` — the repo issue tracker

No functional change; metadata only.

### Verification

`ts/package.json` still parses as valid JSON, and `bun install` in `ts/` is unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository information, homepage details, and issue-tracker links to the project metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->