### PR TITLE
fix(sqlite): tokenize search queries instead of matching the whole string

### DIFF
--- a/ts/src/backends/sqlite.ts
+++ b/ts/src/backends/sqlite.ts
@@ -247,12 +247,14 @@ export class SQLiteBackend implements GraphBackend {
     const relevanceParams: unknown[] = [];
 
     const phrase = searchQuery.query ? `%${escapeLikeValue(searchQuery.query)}%` : undefined;
+    const explicitTerms = normalizeSearchTerms(searchQuery.terms);
     const terms =
-      searchQuery.terms.length > 0
-        ? searchQuery.terms.map((term) => term.toLowerCase())
+      explicitTerms.length > 0
+        ? explicitTerms
         : searchQuery.query
           ? tokenizeSearchQuery(searchQuery.query)
           : [];
+    const termsCameFromQuery = explicitTerms.length === 0;
 
     if (terms.length > 0) {
       const joiner = searchQuery.match_mode === "all" ? " AND " : " OR ";
@@ -277,7 +279,7 @@ export class SQLiteBackend implements GraphBackend {
 
       conditions.push(`(${termConditions.join(joiner)})`);
 
-      if (phrase !== undefined) {
+      if (phrase !== undefined && termsCameFromQuery) {
         scoreParts.push(
           `(CASE WHEN title ${LIKE} THEN 12 ELSE 0 END)`,
           `(CASE WHEN content ${LIKE} THEN 6 ELSE 0 END)`
@@ -622,6 +624,17 @@ const LIKE = `LIKE ? ESCAPE '${LIKE_ESCAPE_CHAR}'`;
 
 function escapeLikeValue(value: string): string {
   return value.replace(/[\\%_]/g, (char) => `${LIKE_ESCAPE_CHAR}${char}`);
+}
+
+function normalizeSearchTerms(terms: string[]): string[] {
+  const normalized = new Set<string>();
+  for (const term of terms) {
+    const trimmed = term.trim().toLowerCase();
+    if (trimmed.length === 0) continue;
+    normalized.add(trimmed);
+    if (normalized.size >= MAX_SEARCH_TERMS) break;
+  }
+  return [...normalized];
 }
 
 function tokenizeSearchQuery(query: string): string[] {

--- a/ts/src/backends/sqlite.ts
+++ b/ts/src/backends/sqlite.ts
@@ -622,10 +622,23 @@ const LIKE_ESCAPE_CHAR = "\\";
 
 const LIKE = `LIKE ? ESCAPE '${LIKE_ESCAPE_CHAR}'`;
 
+/**
+ * Escape the LIKE wildcards `%` and `_` so a value is compared literally.
+ *
+ * Pair with the {@link LIKE} operator fragment, which supplies the matching
+ * ESCAPE clause.
+ */
 function escapeLikeValue(value: string): string {
   return value.replace(/[\\%_]/g, (char) => `${LIKE_ESCAPE_CHAR}${char}`);
 }
 
+/**
+ * Normalize a caller-supplied list of search terms.
+ *
+ * Trims and lowercases each entry, discards empty ones, de-duplicates, and
+ * caps the result at {@link MAX_SEARCH_TERMS} so the generated SQL stays
+ * within SQLite's expression limits.
+ */
 function normalizeSearchTerms(terms: string[]): string[] {
   const normalized = new Set<string>();
   for (const term of terms) {
@@ -637,6 +650,15 @@ function normalizeSearchTerms(terms: string[]): string[] {
   return [...normalized];
 }
 
+/**
+ * Split a natural-language query into search terms.
+ *
+ * Retains intra-word punctuation so dotted, hyphenated and underscored
+ * identifiers survive as single terms, discards stopwords and single
+ * characters, de-duplicates, and caps the result at {@link MAX_SEARCH_TERMS}.
+ * Returns an empty array when nothing usable remains, leaving the caller to
+ * fall back to matching the raw query string.
+ */
 function tokenizeSearchQuery(query: string): string[] {
   const terms = new Set<string>();
   for (const raw of query.toLowerCase().split(/[^\p{L}\p{N}_.\-/]+/u)) {

--- a/ts/src/backends/sqlite.ts
+++ b/ts/src/backends/sqlite.ts
@@ -243,10 +243,52 @@ export class SQLiteBackend implements GraphBackend {
     const conditions: string[] = [];
     const params: unknown[] = [];
 
-    if (searchQuery.query) {
-      conditions.push("(title LIKE ? OR content LIKE ? OR summary LIKE ?)");
-      const pattern = `%${searchQuery.query}%`;
-      params.push(pattern, pattern, pattern);
+    let relevanceSql = "0";
+    const relevanceParams: unknown[] = [];
+
+    const phrase = searchQuery.query ? `%${escapeLikeValue(searchQuery.query)}%` : undefined;
+    const terms =
+      searchQuery.terms.length > 0
+        ? searchQuery.terms.map((term) => term.toLowerCase())
+        : searchQuery.query
+          ? tokenizeSearchQuery(searchQuery.query)
+          : [];
+
+    if (terms.length > 0) {
+      const joiner = searchQuery.match_mode === "all" ? " AND " : " OR ";
+      const termConditions: string[] = [];
+      const scoreParts: string[] = [];
+
+      for (const term of terms) {
+        const pattern = `%${escapeLikeValue(term)}%`;
+        termConditions.push(
+          `(title ${LIKE} OR content ${LIKE} OR summary ${LIKE} OR tags ${LIKE})`
+        );
+        params.push(pattern, pattern, pattern, pattern);
+
+        scoreParts.push(
+          `(CASE WHEN title ${LIKE} THEN 4 ELSE 0 END)`,
+          `(CASE WHEN tags ${LIKE} THEN 3 ELSE 0 END)`,
+          `(CASE WHEN summary ${LIKE} THEN 2 ELSE 0 END)`,
+          `(CASE WHEN content ${LIKE} THEN 1 ELSE 0 END)`
+        );
+        relevanceParams.push(pattern, pattern, pattern, pattern);
+      }
+
+      conditions.push(`(${termConditions.join(joiner)})`);
+
+      if (phrase !== undefined) {
+        scoreParts.push(
+          `(CASE WHEN title ${LIKE} THEN 12 ELSE 0 END)`,
+          `(CASE WHEN content ${LIKE} THEN 6 ELSE 0 END)`
+        );
+        relevanceParams.push(phrase, phrase);
+      }
+
+      relevanceSql = scoreParts.join(" + ");
+    } else if (phrase !== undefined) {
+      conditions.push(`(title ${LIKE} OR content ${LIKE} OR summary ${LIKE})`);
+      params.push(phrase, phrase, phrase);
     }
 
     if (searchQuery.memory_types.length > 0) {
@@ -279,14 +321,20 @@ export class SQLiteBackend implements GraphBackend {
     }
 
     const whereClause = conditions.length > 0 ? conditions.join(" AND ") : "1=1";
-    params.push(searchQuery.limit);
-    params.push(searchQuery.offset ?? 0);
+    const boundParams = [
+      ...relevanceParams,
+      ...params,
+      searchQuery.limit,
+      searchQuery.offset ?? 0,
+    ];
 
     const rows = this.db
       .query(
-        `SELECT * FROM memories WHERE ${whereClause} ORDER BY importance DESC, created_at DESC LIMIT ? OFFSET ?`
+        `SELECT * FROM (
+           SELECT *, ${relevanceSql} AS relevance FROM memories WHERE ${whereClause}
+         ) ORDER BY relevance DESC, importance DESC, created_at DESC LIMIT ? OFFSET ?`
       )
-      .all(...(params as any[])) as Record<string, unknown>[];
+      .all(...(boundParams as any[])) as Record<string, unknown>[];
 
     return rows.map(rowToMemory).filter((m): m is Memory => m !== null);
   }
@@ -558,6 +606,34 @@ export class SQLiteBackend implements GraphBackend {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+const SEARCH_STOPWORDS = new Set([
+  "a", "an", "and", "any", "are", "as", "at", "be", "but", "by", "for", "from",
+  "how", "in", "into", "is", "it", "its", "of", "on", "or", "that", "the",
+  "their", "them", "then", "there", "these", "they", "this", "to", "was",
+  "were", "what", "when", "where", "which", "who", "why", "with",
+]);
+
+const MAX_SEARCH_TERMS = 12;
+
+const LIKE_ESCAPE_CHAR = "\\";
+
+const LIKE = `LIKE ? ESCAPE '${LIKE_ESCAPE_CHAR}'`;
+
+function escapeLikeValue(value: string): string {
+  return value.replace(/[\\%_]/g, (char) => `${LIKE_ESCAPE_CHAR}${char}`);
+}
+
+function tokenizeSearchQuery(query: string): string[] {
+  const terms = new Set<string>();
+  for (const raw of query.toLowerCase().split(/[^\p{L}\p{N}_.\-/]+/u)) {
+    const term = raw.replace(/^[.\-/]+|[.\-/]+$/g, "");
+    if (term.length < 2 || SEARCH_STOPWORDS.has(term)) continue;
+    terms.add(term);
+    if (terms.size >= MAX_SEARCH_TERMS) break;
+  }
+  return [...terms];
+}
 
 function toIso(value: string | Date): string {
   return value instanceof Date ? value.toISOString() : value;

--- a/ts/tests/sqlite-backend.test.ts
+++ b/ts/tests/sqlite-backend.test.ts
@@ -309,6 +309,57 @@ describe("SQLiteBackend search matching", () => {
     expect(results[0].title).toBe("Chromedriver autodownload");
   });
 
+  test("trims and de-duplicates explicit terms and drops empty ones", async () => {
+    await db.storeMemory(
+      createMemory({ type: "solution", title: "Chromedriver autodownload", content: "Namespaced flag." })
+    );
+    await db.storeMemory(
+      createMemory({ type: "solution", title: "Unrelated memory", content: "Nothing in common." })
+    );
+
+    const results = await db.searchMemories(
+      searchQuery({ query: undefined, terms: ["  Chromedriver  ", "chromedriver", "", "   "] })
+    );
+    expect(results.length).toBe(1);
+    expect(results[0].title).toBe("Chromedriver autodownload");
+  });
+
+  test("caps an oversized explicit terms list without failing", async () => {
+    await db.storeMemory(
+      createMemory({ type: "solution", title: "Chromedriver autodownload", content: "Namespaced flag." })
+    );
+
+    const terms = ["chromedriver", ...Array.from({ length: 300 }, (_, i) => `absent${i}`)];
+    const results = await db.searchMemories(searchQuery({ query: undefined, terms }));
+    expect(results.length).toBe(1);
+    expect(results[0].title).toBe("Chromedriver autodownload");
+  });
+
+  test("does not score the query phrase when explicit terms take precedence", async () => {
+    await db.storeMemory(
+      createMemory({
+        type: "solution",
+        title: "Alpha record",
+        content: "Mentions chromedriver only.",
+        importance: 0.9,
+      })
+    );
+    await db.storeMemory(
+      createMemory({
+        type: "solution",
+        title: "Beta record",
+        content: "Mentions chromedriver and the ignored phrase too.",
+        importance: 0.4,
+      })
+    );
+
+    const results = await db.searchMemories(
+      searchQuery({ query: "the ignored phrase", terms: ["chromedriver"] })
+    );
+    expect(results.length).toBe(2);
+    expect(results[0].title).toBe("Alpha record");
+  });
+
   test("treats an underscore in a term as a literal character", async () => {
     await db.storeMemory(
       createMemory({ type: "solution", title: "order_id lookup", content: "Literal underscore." })

--- a/ts/tests/sqlite-backend.test.ts
+++ b/ts/tests/sqlite-backend.test.ts
@@ -185,3 +185,200 @@ describe("SQLiteBackend", () => {
     expect(health.backend_type).toBe("sqlite");
   });
 });
+
+const SEARCH_TEST_DB = join(tmpdir(), `mg-search-test-${Date.now()}.db`);
+
+describe("SQLiteBackend search matching", () => {
+  let backend: SQLiteBackend;
+  let db: MemoryDatabase;
+
+  const searchQuery = (overrides: Record<string, unknown>) => ({
+    query: undefined,
+    terms: [],
+    memory_types: [],
+    tags: [],
+    project_path: undefined,
+    languages: [],
+    frameworks: [],
+    min_importance: undefined,
+    min_confidence: undefined,
+    min_effectiveness: undefined,
+    created_after: undefined,
+    created_before: undefined,
+    limit: 50,
+    offset: 0,
+    include_relationships: true,
+    search_tolerance: "normal" as const,
+    match_mode: "any" as const,
+    relationship_filter: undefined,
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    backend = new SQLiteBackend(SEARCH_TEST_DB);
+    await backend.connect();
+    await backend.initializeSchema();
+    db = new MemoryDatabase(backend);
+  });
+
+  afterEach(async () => {
+    await backend.disconnect();
+    try {
+      if (existsSync(SEARCH_TEST_DB)) unlinkSync(SEARCH_TEST_DB);
+    } catch {
+      // ignore
+    }
+  });
+
+  test("matches a multi-word query whose words are not adjacent", async () => {
+    await db.storeMemory(
+      createMemory({
+        type: "solution",
+        title: "Pinch zoom crashes Safari on iOS",
+        content: "Reproduced on a physical iPhone after two gesture cycles.",
+      })
+    );
+
+    const results = await db.searchMemories(searchQuery({ query: "iOS pinch crash" }));
+    expect(results.length).toBe(1);
+  });
+
+  test("is insensitive to word order", async () => {
+    await db.storeMemory(
+      createMemory({ type: "error", title: "Setup traps that wasted time", content: "Four traps." })
+    );
+
+    const forward = await db.searchMemories(searchQuery({ query: "wasted time" }));
+    const reversed = await db.searchMemories(searchQuery({ query: "time wasted" }));
+    expect(forward.length).toBe(1);
+    expect(reversed.length).toBe(1);
+  });
+
+  test("matches terms against tags", async () => {
+    await db.storeMemory(
+      createMemory({
+        type: "workflow",
+        title: "Device automation",
+        content: "Start the server.",
+        tags: ["appium", "android"],
+      })
+    );
+
+    const results = await db.searchMemories(searchQuery({ query: "appium setup" }));
+    expect(results.length).toBe(1);
+  });
+
+  test("match_mode 'all' requires every term to match", async () => {
+    await db.storeMemory(
+      createMemory({ type: "solution", title: "Android pinch zoom", content: "Works via W3C actions." })
+    );
+    await db.storeMemory(
+      createMemory({ type: "solution", title: "Endsheet fade in", content: "Delayed reveal." })
+    );
+
+    const any = await db.searchMemories(searchQuery({ query: "android endsheet", match_mode: "any" }));
+    expect(any.length).toBe(2);
+
+    const all = await db.searchMemories(searchQuery({ query: "android endsheet", match_mode: "all" }));
+    expect(all.length).toBe(0);
+  });
+
+  test("honours an explicit terms list", async () => {
+    await db.storeMemory(
+      createMemory({ type: "solution", title: "Chromedriver autodownload", content: "Namespaced flag." })
+    );
+
+    const results = await db.searchMemories(
+      searchQuery({ query: "ignored when terms are given", terms: ["chromedriver"] })
+    );
+    expect(results.length).toBe(1);
+  });
+
+  test("applies an explicit terms list when no query is given", async () => {
+    await db.storeMemory(
+      createMemory({ type: "solution", title: "Chromedriver autodownload", content: "Namespaced flag." })
+    );
+    await db.storeMemory(
+      createMemory({ type: "solution", title: "Unrelated memory", content: "Nothing in common." })
+    );
+
+    const results = await db.searchMemories(
+      searchQuery({ query: undefined, terms: ["chromedriver"] })
+    );
+    expect(results.length).toBe(1);
+    expect(results[0].title).toBe("Chromedriver autodownload");
+  });
+
+  test("treats an underscore in a term as a literal character", async () => {
+    await db.storeMemory(
+      createMemory({ type: "solution", title: "order_id lookup", content: "Literal underscore." })
+    );
+    await db.storeMemory(
+      createMemory({ type: "solution", title: "orderXid lookup", content: "Wildcard would match this." })
+    );
+
+    const results = await db.searchMemories(searchQuery({ query: "order_id" }));
+    expect(results.length).toBe(1);
+    expect(results[0].title).toBe("order_id lookup");
+  });
+
+  test("does not treat a wildcard-only query as a match-all", async () => {
+    await db.storeMemory(
+      createMemory({ type: "solution", title: "First memory", content: "Content one." })
+    );
+    await db.storeMemory(
+      createMemory({ type: "solution", title: "Second memory", content: "Content two." })
+    );
+
+    expect((await db.searchMemories(searchQuery({ query: "%" }))).length).toBe(0);
+    expect((await db.searchMemories(searchQuery({ query: "%%" }))).length).toBe(0);
+  });
+
+  test("ranks a title match above a more important body-only match", async () => {
+    await db.storeMemory(
+      createMemory({
+        type: "solution",
+        title: "Unrelated title",
+        content: "Mentions pagination once.",
+        importance: 0.9,
+      })
+    );
+    await db.storeMemory(
+      createMemory({
+        type: "solution",
+        title: "Pagination offset fix",
+        content: "Unrelated body.",
+        importance: 0.4,
+      })
+    );
+
+    const results = await db.searchMemories(searchQuery({ query: "pagination" }));
+    expect(results.length).toBe(2);
+    expect(results[0].title).toBe("Pagination offset fix");
+  });
+
+  test("keeps punctuation inside identifiers", async () => {
+    await db.storeMemory(
+      createMemory({ type: "fix", title: "next.config.js rewrite", content: "Proxy the embed route." })
+    );
+    await db.storeMemory(
+      createMemory({ type: "fix", title: "Unrelated", content: "No config reference here." })
+    );
+
+    const results = await db.searchMemories(searchQuery({ query: "next.config.js" }));
+    expect(results.length).toBe(1);
+    expect(results[0].title).toBe("next.config.js rewrite");
+  });
+
+  test("falls back to the raw query when only stopwords remain", async () => {
+    await db.storeMemory(
+      createMemory({ type: "solution", title: "The and of", content: "Literal phrase in title." })
+    );
+
+    const hit = await db.searchMemories(searchQuery({ query: "the and of" }));
+    expect(hit.length).toBe(1);
+
+    const miss = await db.searchMemories(searchQuery({ query: "of and the" }));
+    expect(miss.length).toBe(0);
+  });
+});


### PR DESCRIPTION
### Summary

On the SQLite backend, `searchMemories` wrapped the **entire** query string in one `LIKE '%...%'`, so `recall` — documented as "fuzzy natural language search" — was really a literal, word-order-sensitive substring match. Any multi-word question silently returned nothing unless it appeared verbatim in one field.

### How I hit it

I asked for something I had definitely stored:

```
$ memorygraph recall --query "mobile ticket validation strategy native testing android ios"
No memories found matching your query.
```

The store had 27 memories, six of them directly on that topic. Nothing errored, `memorygraph health` said `Healthy`, and short queries worked fine — so it read as an empty store rather than a broken query. That is the part that cost me the most time: the failure is silent and looks like the absence of data.

Minimal reproduction of the underlying behaviour — same record, same words, different order:

```
$ memorygraph recall --query "wasted time"   # -> 1 result
$ memorygraph recall --query "time wasted"   # -> No memories found
```

### Root cause

`ts/src/backends/sqlite.ts`:

```ts
if (searchQuery.query) {
  conditions.push("(title LIKE ? OR content LIKE ? OR summary LIKE ?)");
  const pattern = `%${searchQuery.query}%`;
  params.push(pattern, pattern, pattern);
}
```

Two consequences:

1. **No tokenization.** The whole query is one pattern, so word order and every intervening character matter. A natural-language query essentially never matches.
2. **`terms` and `match_mode` are ignored.** `handleRecallMemories` builds a `SearchQuery` with `match_mode: "any"`, and the CLI exposes `--match-mode`, but this backend reads neither — so `--match-mode all` silently did nothing here. `tags` was also not searched, only filtered on.

### Changes

- Split the query into terms; an explicit `SearchQuery.terms` list takes precedence over tokenizing `query`, and is honoured whether or not `query` is present.
- Match each term across `title`, `content`, `summary` and `tags`, joined by `OR` or `AND` according to `match_mode`.
- Order by a relevance score computed in SQL — per-term hits weighted by field (title > tags > summary > content), plus a bonus when the whole phrase appears verbatim — keeping the existing `importance` / `created_at` ordering as tie-breakers, so ranking only ever refines the previous order.
- Tokenizing keeps intra-word `. - / _` so identifiers survive as single terms, drops stopwords and one-character tokens, de-duplicates, and caps at 12 terms to bound the generated SQL.
- A query that tokenizes to nothing (all stopwords or punctuation) falls back to the previous raw-string match, so that path is preserved rather than regressed.
- Escape `%`, `_` and the escape character itself in every value interpolated into a LIKE pattern, with a matching `ESCAPE` clause on each `LIKE`, so those characters compare literally.

Scoring parameters bind before the `WHERE` parameters, and the score lives in a subquery so it can be referenced by `ORDER BY`.

### Tests

Added 14 tests to `ts/tests/sqlite-backend.test.ts`. **12 of them fail before the commits that introduce them** and all pass after:

```
# before
(fail) matches a multi-word query whose words are not adjacent
(fail) is insensitive to word order
(fail) matches terms against tags
(fail) match_mode 'all' requires every term to match
(fail) honours an explicit terms list
(fail) applies an explicit terms list when no query is given
(fail) treats an underscore in a term as a literal character
(fail) does not treat a wildcard-only query as a match-all
(fail) ranks a title match above a more important body-only match
 11 pass, 9 fail
```

The three tests added in the second commit (`trims and de-duplicates explicit terms and drops empty ones`, `caps an oversized explicit terms list without failing`, `does not score the query phrase when explicit terms take precedence`) each fail against the first commit.

The remaining two — identifier punctuation and the stopword-only fallback — pass both before and after by design; they guard the behaviour this change could plausibly break.

Full suite: **111 pass, 0 fail** (97 before). `npx tsc --noEmit` is clean.

### Note on scope

Only the SQLite backend is touched. The FalkorDB path has the same whole-query issue (`m.title CONTAINS $query OR ...`) and is left alone deliberately — #11 is actively reworking that file, and I did not want to collide with it. Happy to follow up there once it lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved memory search with natural-language query processing.
  * Searches across titles, content, summaries, and tags.
  * Added “any term” and “all terms” matching options.
  * Results are ranked by relevance, with exact phrase matches prioritized.

* **Bug Fixes**
  * Improved handling of punctuation, duplicate terms, and wildcard characters.
  * Stopword-only or unsupported queries now fall back to reliable substring matching.
  * Search terms are normalized and safely handled for more consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
